### PR TITLE
fix(bootstrap): replace secrets: inherit with explicit passing for cross-org compatibility

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -423,7 +423,8 @@ jobs:
       )
     needs: info
     uses: ./.github/workflows/terraform-init.yml
-    secrets: inherit
+    secrets:
+      AZURE_AD_CLIENT_SECRET: ${{ secrets.AZURE_AD_CLIENT_SECRET }}
     with:
       environment: ${{ inputs.environment }}
       level: ${{ inputs.level }}
@@ -475,7 +476,14 @@ jobs:
       needs.init.outputs.deny_reason == ''
     needs: [info, init]
     uses: ./.github/workflows/terraform-job.yml
-    secrets: inherit
+    secrets:
+      AZURE_AD_CLIENT_SECRET:  ${{ secrets.AZURE_AD_CLIENT_SECRET }}
+      INFRACOST_API_KEY:        ${{ secrets.INFRACOST_API_KEY }}
+      LIBRARY_01_PRIVATE_KEY:  ${{ secrets.LIBRARY_01_PRIVATE_KEY }}
+      LIBRARY_02_PRIVATE_KEY:  ${{ secrets.LIBRARY_02_PRIVATE_KEY }}
+      LIBRARY_03_PRIVATE_KEY:  ${{ secrets.LIBRARY_03_PRIVATE_KEY }}
+      LIBRARY_04_PRIVATE_KEY:  ${{ secrets.LIBRARY_04_PRIVATE_KEY }}
+      LIBRARY_05_PRIVATE_KEY:  ${{ secrets.LIBRARY_05_PRIVATE_KEY }}
     with:
       environment: ${{ inputs.environment }}
       level: ${{ inputs.level }}
@@ -532,7 +540,6 @@ jobs:
       github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/scan')
     needs: info
     uses: ./.github/workflows/terraform-scan.yml
-    secrets: inherit
     with:
       log_severity: ${{ inputs.log_severity }}
       pull_request_head_ref: ${{ needs.info.outputs.head_ref }}

--- a/.github/workflows/terraform-init.yml
+++ b/.github/workflows/terraform-init.yml
@@ -846,6 +846,9 @@ jobs:
                   --datasource-id ${{ steps.az_state_sa.outputs.state_storage_account_id }} \
                   --only-show-errors)
                 echo "  ...Create instance"
+                bvi_request=$(echo "${bvi_request}" | jq \
+                  --arg container "${{ inputs.state_container }}" \
+                  '.properties.policy_info.policy_parameters = {"backup_datasource_parameters_list": [{"containers_backup_friendly_names": [$container], "object_type": "BlobBackupDatasourceParameters"}]}')
                 bvi_request=$(echo $bvi_request | sed 's/"/\\"/g')
                 +cmdstd az dataprotection backup-instance create \
                   -g ${{ steps.az_state_rg.outputs.state_resource_group_name }} \

--- a/.github/workflows/terraform-init.yml
+++ b/.github/workflows/terraform-init.yml
@@ -848,7 +848,7 @@ jobs:
                 echo "  ...Create instance"
                 bvi_request=$(echo "${bvi_request}" | jq \
                   --arg container "${{ inputs.state_container }}" \
-                  '.properties.policy_info.policy_parameters = {"backup_datasource_parameters_list": [{"containers_backup_friendly_names": [$container], "object_type": "BlobBackupDatasourceParameters"}]}')
+                  '.properties.policy_info.policy_parameters = {"backup_datasource_parameters_list": [{"containers_list": [$container], "object_type": "BlobBackupDatasourceParameters"}]}')
                 bvi_request=$(echo $bvi_request | sed 's/"/\\"/g')
                 +cmdstd az dataprotection backup-instance create \
                   -g ${{ steps.az_state_rg.outputs.state_resource_group_name }} \

--- a/.github/workflows/terraform-init.yml
+++ b/.github/workflows/terraform-init.yml
@@ -846,10 +846,10 @@ jobs:
                   --datasource-id ${{ steps.az_state_sa.outputs.state_storage_account_id }} \
                   --only-show-errors)
                 echo "  ...Create instance"
-                bvi_request=$(echo "${bvi_request}" | jq \
+                bvi_request=$(echo "${bvi_request}" | jq -c \
                   --arg container "${{ inputs.state_container }}" \
                   '.properties.policy_info.policy_parameters = {"backup_datasource_parameters_list": [{"containers_list": [$container], "object_type": "BlobBackupDatasourceParameters"}]}')
-                bvi_request=$(echo $bvi_request | sed 's/"/\\"/g')
+                bvi_request=$(echo "$bvi_request" | sed 's/"/\\"/g')
                 +cmdstd az dataprotection backup-instance create \
                   -g ${{ steps.az_state_rg.outputs.state_resource_group_name }} \
                   --vault-name ${{ steps.az_state_rg.outputs.state_resource_group_name }}-bv \

--- a/.github/workflows/terraform-job.yml
+++ b/.github/workflows/terraform-job.yml
@@ -1124,7 +1124,7 @@ jobs:
         run: |
           set -x
           start_path=$(readlink -f .)
-          main_path=$(readlink -f main/${{ inputs.code_path }})
+          main_path="${start_path}/main/${{ inputs.code_path }}"
           mkdir -p ${start_path}/logs
           touch "${start_path}/logs/steps.log"
           if [ -f "${start_path}/plan.json" ] && [ -s "${start_path}/plan.json" ]; then

--- a/.github/workflows/terraform-job.yml
+++ b/.github/workflows/terraform-job.yml
@@ -1114,37 +1114,56 @@ jobs:
       - name: Generate infrastructure cost diff
         id: infracost-diff
         if: contains(inputs.terraform_command, 'plan')
-        continue-on-error: true
         shell: bash
         run: |
-          set -x
+          set -Eeu
           start_path=$(readlink -f .)
           code_path=$(readlink -f src/${{ inputs.code_path }})
-          echo "DEBUG: start_path=$start_path code_path=$code_path"
-          echo "DEBUG: which infracost=$(which infracost 2>&1 || echo NOT_FOUND)"
-          echo "DEBUG: plan.json exists=$(ls -la ${start_path}/plan.json 2>&1 || echo MISSING)"
-          echo "DEBUG: tfplan exists=$(ls -la ${start_path}/tfplan 2>&1 || echo MISSING)"
+          main_path=$(readlink -f main/${{ inputs.code_path }})
           mkdir -p ${start_path}/logs
           log_file="${start_path}/logs/steps.log"
-          touch "$log_file"
+          touch $log_file
+          trap 'error_handler $? $LINENO "$BASH_COMMAND" $log_file' ERR
+          error_handler() {
+            if [[ "$3" != 'return ${PIPESTATUS[0]}' ]]; then
+              msg="Error $1 at line $(expr $2 + 1) in '${{ github.action }}': $3"
+              echo "::error file=${{ github.action }},line=$(expr $2 + 1)::$msg"
+              echo "$(date '+%Y-%m-%d %H:%M:%S') $msg" >>$4
+            fi
+            exit $1
+          }
           if [ -f "${start_path}/plan.json" ] && [ -s "${start_path}/plan.json" ]; then
             echo "Using pre-generated plan JSON for infracost ($(wc -c < ${start_path}/plan.json) bytes)"
             plan_path="${start_path}/plan.json"
           else
-            echo "No plan.json found, cannot run infracost without re-init"
+            echo "::warning::plan.json not found — infracost skipped"
             exit 0
           fi
-          echo "Running: infracost breakdown --path=$plan_path"
-          infracost breakdown \
-            --log-level ${{ inputs.log_severity }} \
-            --no-color \
-            --path="$plan_path" \
-            --format=json \
-            --out-file="${start_path}/infracost.json" 2>&1 || {
-            echo "::warning::infracost breakdown failed (exit $?), skipping cost diff"
-            exit 0
-          }
-          echo "Infracost breakdown complete"
+          if [[ -n "$(find main/ -maxdepth 1 -name "*.tf" -type f)" ]]; then
+            echo "Create infracost baseline using plan in base branch (main)"
+            infracost breakdown \
+              --log-level ${{ inputs.log_severity }} \
+              --no-color \
+              --path=$main_path \
+              --format=json \
+              --out-file=$start_path/infracost-base.json
+            echo "Compare current commit with baseline from plan in base branch (main)"
+            infracost diff \
+              --log-level ${{ inputs.log_severity }} \
+              --no-color \
+              --path=$plan_path \
+              --format=json \
+              --compare-to=$start_path/infracost-base.json \
+              --out-file=$start_path/infracost.json
+          else
+            echo "Create infracost breakdown using plan from current commit"
+            infracost breakdown \
+              --log-level ${{ inputs.log_severity }} \
+              --no-color \
+              --path=$plan_path \
+              --format=json \
+              --out-file=$start_path/infracost.json
+          fi
 
       - name: Add or update infrastructure cost comment
         id: infracost_comment

--- a/.github/workflows/terraform-job.yml
+++ b/.github/workflows/terraform-job.yml
@@ -648,6 +648,7 @@ jobs:
             -o tsv)
           if [ "${blob_exists}" == 'true' ]; then
             echo "Download https://${state_storage_account_name}.blob.core.windows.net/${{ inputs.state_container }}/${blob}"
+            mkdir -p "$(dirname "${start_path}/logs/${blob}.before")"
             +cmdstd az storage blob download \
               --name $blob \
               --container-name ${{ inputs.state_container }} \
@@ -972,6 +973,7 @@ jobs:
             -o tsv)
           if [ "${blob_exists}" == 'true' ]; then
             echo "Download https://${state_storage_account_name}.blob.core.windows.net/${{ inputs.state_container }}/${blob}"
+            mkdir -p "$(dirname "${start_path}/logs/${blob}.after")"
             +cmdstd az storage blob download \
               --name $blob \
               --container-name ${{ inputs.state_container }} \

--- a/.github/workflows/terraform-job.yml
+++ b/.github/workflows/terraform-job.yml
@@ -1125,6 +1125,13 @@ jobs:
             fi
             exit $1
           }
+          if [ -f "${start_path}/tfplan" ]; then
+            echo "Converting binary plan to JSON for infracost"
+            terraform -chdir=$code_path show -no-color -json ${start_path}/tfplan > ${start_path}/plan.json
+            plan_path="${start_path}/plan.json"
+          else
+            plan_path="$code_path"
+          fi
           if [[ -n "$(find main/ -maxdepth 1 -name "*.tf" -type f)" ]]; then
             echo "Create infracost baseline using plan in base branch (main)"
             infracost breakdown \
@@ -1137,7 +1144,7 @@ jobs:
             infracost diff \
               --log-level ${{ inputs.log_severity }} \
               --no-color \
-              --path=$code_path \
+              --path=$plan_path \
               --format=json \
               --compare-to=$start_path/infracost-base.json \
               --out-file=$start_path/infracost.json
@@ -1146,7 +1153,7 @@ jobs:
             infracost breakdown \
               --log-level ${{ inputs.log_severity }} \
               --no-color \
-              --path=$code_path \
+              --path=$plan_path \
               --format=json \
               --out-file=$start_path/infracost.json
           fi

--- a/.github/workflows/terraform-job.yml
+++ b/.github/workflows/terraform-job.yml
@@ -930,6 +930,13 @@ jobs:
           if [[ '${{ inputs.terraform_command }}' == *'apply'* ]]; then
             echo "applied=true" >> $GITHUB_OUTPUT
           fi
+          if [[ '${{ inputs.terraform_command }}' == *'plan'* ]] && [ -f "${start_path}/tfplan" ]; then
+            echo "Exporting plan JSON for infracost (providers still initialized)"
+            terraform -chdir=$code_path show -no-color -json ${start_path}/tfplan > ${start_path}/plan.json 2>&1 || {
+              echo "Warning: terraform show -json failed, infracost will fall back to directory mode"
+              rm -f ${start_path}/plan.json
+            }
+          fi
           find . -name "backend.*.tf" -delete || true
           find . -name "terraform.tfstate*" -delete || true
 
@@ -1125,11 +1132,11 @@ jobs:
             fi
             exit $1
           }
-          if [ -f "${start_path}/tfplan" ]; then
-            echo "Converting binary plan to JSON for infracost"
-            terraform -chdir=$code_path show -no-color -json ${start_path}/tfplan > ${start_path}/plan.json
+          if [ -f "${start_path}/plan.json" ] && [ -s "${start_path}/plan.json" ]; then
+            echo "Using pre-generated plan JSON for infracost ($(wc -c < ${start_path}/plan.json) bytes)"
             plan_path="${start_path}/plan.json"
           else
+            echo "No plan.json found, using code directory (infracost will init terraform)"
             plan_path="$code_path"
           fi
           if [[ -n "$(find main/ -maxdepth 1 -name "*.tf" -type f)" ]]; then

--- a/.github/workflows/terraform-job.yml
+++ b/.github/workflows/terraform-job.yml
@@ -1122,22 +1122,11 @@ jobs:
         if: contains(inputs.terraform_command, 'plan')
         shell: bash
         run: |
-          set -Eeu
+          set -x
           start_path=$(readlink -f .)
-          code_path=$(readlink -f src/${{ inputs.code_path }})
           main_path=$(readlink -f main/${{ inputs.code_path }})
           mkdir -p ${start_path}/logs
-          log_file="${start_path}/logs/steps.log"
-          touch $log_file
-          trap 'error_handler $? $LINENO "$BASH_COMMAND" $log_file' ERR
-          error_handler() {
-            if [[ "$3" != 'return ${PIPESTATUS[0]}' ]]; then
-              msg="Error $1 at line $(expr $2 + 1) in '${{ github.action }}': $3"
-              echo "::error file=${{ github.action }},line=$(expr $2 + 1)::$msg"
-              echo "$(date '+%Y-%m-%d %H:%M:%S') $msg" >>$4
-            fi
-            exit $1
-          }
+          touch "${start_path}/logs/steps.log"
           if [ -f "${start_path}/plan.json" ] && [ -s "${start_path}/plan.json" ]; then
             echo "Using pre-generated plan JSON for infracost ($(wc -c < ${start_path}/plan.json) bytes)"
             plan_path="${start_path}/plan.json"
@@ -1145,30 +1134,39 @@ jobs:
             echo "::warning::plan.json not found — infracost skipped"
             exit 0
           fi
-          if [[ -d "$main_path" ]] && [[ -n "$(find "$main_path" -maxdepth 1 -name "*.tf" -type f)" ]]; then
+          if [[ -d "$main_path" ]] && [[ -n "$(find "$main_path" -maxdepth 1 -name "*.tf" -type f 2>/dev/null)" ]]; then
             echo "Create infracost baseline using plan in base branch (main)"
             infracost breakdown \
               --log-level ${{ inputs.log_severity }} \
               --no-color \
-              --path=$main_path \
+              --path="$main_path" \
               --format=json \
-              --out-file=$start_path/infracost-base.json
+              --out-file="${start_path}/infracost-base.json" 2>&1 || {
+              echo "::warning::infracost baseline failed, skipping cost diff"
+              exit 0
+            }
             echo "Compare current commit with baseline from plan in base branch (main)"
             infracost diff \
               --log-level ${{ inputs.log_severity }} \
               --no-color \
-              --path=$plan_path \
+              --path="$plan_path" \
               --format=json \
-              --compare-to=$start_path/infracost-base.json \
-              --out-file=$start_path/infracost.json
+              --compare-to="${start_path}/infracost-base.json" \
+              --out-file="${start_path}/infracost.json" 2>&1 || {
+              echo "::warning::infracost diff failed, skipping cost diff"
+              exit 0
+            }
           else
             echo "Create infracost breakdown using plan from current commit"
             infracost breakdown \
               --log-level ${{ inputs.log_severity }} \
               --no-color \
-              --path=$plan_path \
+              --path="$plan_path" \
               --format=json \
-              --out-file=$start_path/infracost.json
+              --out-file="${start_path}/infracost.json" 2>&1 || {
+              echo "::warning::infracost breakdown failed, skipping cost diff"
+              exit 0
+            }
           fi
 
       - name: Add or update infrastructure cost comment

--- a/.github/workflows/terraform-job.yml
+++ b/.github/workflows/terraform-job.yml
@@ -932,10 +932,16 @@ jobs:
           fi
           if [[ '${{ inputs.terraform_command }}' == *'plan'* ]] && [ -f "${start_path}/tfplan" ]; then
             echo "Exporting plan JSON for infracost (providers still initialized)"
-            terraform -chdir=$code_path show -no-color -json ${start_path}/tfplan > ${start_path}/plan.json 2>&1 || {
-              echo "Warning: terraform show -json failed, infracost will fall back to directory mode"
+            tf_plan_json_stderr="${start_path}/logs/terraform_show_json.stderr.log"
+            if terraform -chdir=$code_path show -no-color -json ${start_path}/tfplan > ${start_path}/plan.json 2>"${tf_plan_json_stderr}"; then
+              if ! jq empty "${start_path}/plan.json" >/dev/null 2>&1; then
+                echo "Warning: terraform show -json produced invalid JSON, infracost will be skipped"
+                rm -f ${start_path}/plan.json
+              fi
+            else
+              echo "Warning: terraform show -json failed, infracost will be skipped"
               rm -f ${start_path}/plan.json
-            }
+            fi
           fi
           find . -name "backend.*.tf" -delete || true
           find . -name "terraform.tfstate*" -delete || true
@@ -1139,7 +1145,7 @@ jobs:
             echo "::warning::plan.json not found — infracost skipped"
             exit 0
           fi
-          if [[ -n "$(find main/ -maxdepth 1 -name "*.tf" -type f)" ]]; then
+          if [[ -n "$(find "$main_path" -maxdepth 1 -name "*.tf" -type f)" ]]; then
             echo "Create infracost baseline using plan in base branch (main)"
             infracost breakdown \
               --log-level ${{ inputs.log_severity }} \

--- a/.github/workflows/terraform-job.yml
+++ b/.github/workflows/terraform-job.yml
@@ -1145,7 +1145,7 @@ jobs:
             echo "::warning::plan.json not found — infracost skipped"
             exit 0
           fi
-          if [[ -n "$(find "$main_path" -maxdepth 1 -name "*.tf" -type f)" ]]; then
+          if [[ -d "$main_path" ]] && [[ -n "$(find "$main_path" -maxdepth 1 -name "*.tf" -type f)" ]]; then
             echo "Create infracost baseline using plan in base branch (main)"
             infracost breakdown \
               --log-level ${{ inputs.log_severity }} \

--- a/.github/workflows/terraform-job.yml
+++ b/.github/workflows/terraform-job.yml
@@ -124,7 +124,7 @@ on:
         default: "."
         type: string
       var_path:
-        description: "Path to the configuration files. All .tfvars files in the directory will be expanded."
+        description: "Path to the directory containing .tfvars files, relative to the repo root. Same convention as code_path. Defaults to code_path (tfvars alongside .tf files)."
         required: false
         default: "."
         type: string

--- a/.github/workflows/terraform-job.yml
+++ b/.github/workflows/terraform-job.yml
@@ -784,7 +784,7 @@ jobs:
               echo "error file: ${tf_error_file}"
               arg_vars=''
               if [[ "${command}" =~ (plan|import) ]]; then
-                var_path=$(readlink -f src/${{ inputs.var_path }})
+                var_path=$(readlink -f ${start_path}/src/${{ inputs.var_path }})
                 if [ ! -d "${var_path}" ]; then
                   echo "::error file=${{ github.action }}::Folder ${var_path} does not exist."
                   exit 1

--- a/.github/workflows/terraform-job.yml
+++ b/.github/workflows/terraform-job.yml
@@ -784,7 +784,7 @@ jobs:
               echo "error file: ${tf_error_file}"
               arg_vars=''
               if [[ "${command}" =~ (plan|import) ]]; then
-                var_path=$(readlink -f ${{ inputs.var_path }})
+                var_path=$(readlink -f src/${{ inputs.var_path }})
                 if [ ! -d "${var_path}" ]; then
                   echo "::error file=${{ github.action }}::Folder ${var_path} does not exist."
                   exit 1

--- a/.github/workflows/terraform-job.yml
+++ b/.github/workflows/terraform-job.yml
@@ -1114,56 +1114,37 @@ jobs:
       - name: Generate infrastructure cost diff
         id: infracost-diff
         if: contains(inputs.terraform_command, 'plan')
+        continue-on-error: true
         shell: bash
         run: |
-          set -Eeu
+          set -x
           start_path=$(readlink -f .)
           code_path=$(readlink -f src/${{ inputs.code_path }})
-          main_path=$(readlink -f main/${{ inputs.code_path }})
+          echo "DEBUG: start_path=$start_path code_path=$code_path"
+          echo "DEBUG: which infracost=$(which infracost 2>&1 || echo NOT_FOUND)"
+          echo "DEBUG: plan.json exists=$(ls -la ${start_path}/plan.json 2>&1 || echo MISSING)"
+          echo "DEBUG: tfplan exists=$(ls -la ${start_path}/tfplan 2>&1 || echo MISSING)"
           mkdir -p ${start_path}/logs
           log_file="${start_path}/logs/steps.log"
-          touch $log_file
-          trap 'error_handler $? $LINENO "$BASH_COMMAND" $log_file' ERR
-          error_handler() {
-            if [[ "$3" != 'return ${PIPESTATUS[0]}' ]]; then
-              msg="Error $1 at line $(expr $2 + 1) in '${{ github.action }}': $3"
-              echo "::error file=${{ github.action }},line=$(expr $2 + 1)::$msg"
-              echo "$(date '+%Y-%m-%d %H:%M:%S') $msg" >>$4
-            fi
-            exit $1
-          }
+          touch "$log_file"
           if [ -f "${start_path}/plan.json" ] && [ -s "${start_path}/plan.json" ]; then
             echo "Using pre-generated plan JSON for infracost ($(wc -c < ${start_path}/plan.json) bytes)"
             plan_path="${start_path}/plan.json"
           else
-            echo "No plan.json found, using code directory (infracost will init terraform)"
-            plan_path="$code_path"
+            echo "No plan.json found, cannot run infracost without re-init"
+            exit 0
           fi
-          if [[ -n "$(find main/ -maxdepth 1 -name "*.tf" -type f)" ]]; then
-            echo "Create infracost baseline using plan in base branch (main)"
-            infracost breakdown \
-              --log-level ${{ inputs.log_severity }} \
-              --no-color \
-              --path=$main_path \
-              --format=json \
-              --out-file=$start_path/infracost-base.json
-            echo "Compare current commit with baseline from plan in base branch (main)"
-            infracost diff \
-              --log-level ${{ inputs.log_severity }} \
-              --no-color \
-              --path=$plan_path \
-              --format=json \
-              --compare-to=$start_path/infracost-base.json \
-              --out-file=$start_path/infracost.json
-          else
-            echo "Create infracost breakdown using plan from current commit"
-            infracost breakdown \
-              --log-level ${{ inputs.log_severity }} \
-              --no-color \
-              --path=$plan_path \
-              --format=json \
-              --out-file=$start_path/infracost.json
-          fi
+          echo "Running: infracost breakdown --path=$plan_path"
+          infracost breakdown \
+            --log-level ${{ inputs.log_severity }} \
+            --no-color \
+            --path="$plan_path" \
+            --format=json \
+            --out-file="${start_path}/infracost.json" 2>&1 || {
+            echo "::warning::infracost breakdown failed (exit $?), skipping cost diff"
+            exit 0
+          }
+          echo "Infracost breakdown complete"
 
       - name: Add or update infrastructure cost comment
         id: infracost_comment

--- a/.github/workflows/terraform-job.yml
+++ b/.github/workflows/terraform-job.yml
@@ -1122,6 +1122,7 @@ jobs:
         if: contains(inputs.terraform_command, 'plan')
         shell: bash
         run: |
+          set -Eeuo pipefail
           set -x
           start_path=$(readlink -f .)
           main_path="${start_path}/main/${{ inputs.code_path }}"
@@ -1188,6 +1189,10 @@ jobs:
             fi
             exit $1
           }
+          if [ ! -f "${start_path}/infracost.json" ]; then
+            echo "::warning::infracost.json not found — skipping cost comment"
+            exit 0
+          fi
           infracost comment github --path=$start_path/infracost.json \
             --log-level ${{ inputs.log_severity }} \
             --no-color \


### PR DESCRIPTION
## Summary

Fixes cross-organization reusable workflow compatibility and improves Infracost plan integration across three workflow files.

### bootstrap.yml
- Replace `secrets: inherit` with explicit secret mappings in all nested reusable workflow calls (3 call sites)
- Removes secret inheritance from the scan job
- Required for callers in a different GitHub org where `secrets: inherit` does not propagate explicitly-passed secrets

### terraform-job.yml
- **var_path fix**: resolve `var_path` using `${start_path}/src/` prefix so it resolves correctly after `cd $code_path` changes the working directory
- **plan.json export**: export `terraform show -json` output to `plan.json` for Infracost consumption; stderr redirected to a separate log file; `jq empty` validation before use
- **Infracost step**: restore `set -Eeuo pipefail` (previously `set -x` only, removing errexit/nounset); gate the cost comment step on `infracost.json` existence to prevent hard failure when plan.json generation was skipped
- **State blob subdirs**: `mkdir -p "$(dirname ...)"` before download to handle state names with path separators (e.g. `t-fr1nexus/terraform.tfstate`)
- **terraform show stderr**: separate stderr log file; `jq empty` validation before using plan.json

### terraform-init.yml
- Patch dataprotection backup instance request JSON using `jq -c` (compact output) and `--arg` injection to set `state_container`; quote `echo "$bvi_request"` before `sed` to prevent word-splitting

## Testing

Validated end-to-end against `hoegh-autoliners/fr1nexus` (cross-org caller):
- `/plan` on PR → plan runs, infracost breakdown posted as PR comment
- `/apply` on PR → apply completes, state updated, PR auto-merged