### PR TITLE
fix(infracost): blob-storage run-to-run baseline for accurate cost delta

### DIFF
--- a/.github/workflows/terraform-job.yml
+++ b/.github/workflows/terraform-job.yml
@@ -1139,14 +1139,9 @@ jobs:
             echo "Create infracost baseline using plan in base branch (main)"
             var_file_path="${start_path}/main/${{ inputs.var_path }}/terraform.tfvars"
             if [[ -f "$var_file_path" ]]; then
-              cat > "${start_path}/infracost-base.yml" << EOF
-version: 0.1
-projects:
-  - path: ${main_path}
-    name: ${{ github.repository }}
-    terraform_var_files:
-      - ${var_file_path}
-EOF
+              printf 'version: 0.1\nprojects:\n  - path: %s\n    name: %s\n    terraform_var_files:\n      - %s\n' \
+                "${main_path}" "${{ github.repository }}" "${var_file_path}" \
+                > "${start_path}/infracost-base.yml"
               infracost breakdown \
                 --log-level ${{ inputs.log_severity }} \
                 --no-color \

--- a/.github/workflows/terraform-job.yml
+++ b/.github/workflows/terraform-job.yml
@@ -1136,22 +1136,23 @@ jobs:
             exit 0
           fi
           if [[ -d "$main_path" ]] && [[ -n "$(find "$main_path" -maxdepth 1 -name "*.tf" -type f 2>/dev/null)" ]]; then
-            echo "Create infracost baseline using plan in base branch (main)"
             var_file_path="${start_path}/main/${{ inputs.var_path }}/terraform.tfvars"
             if [[ -f "$var_file_path" ]]; then
-              printf 'version: 0.1\nprojects:\n  - path: %s\n    name: %s\n    terraform_var_files:\n      - %s\n' \
-                "${main_path}" "${{ github.repository }}" "${var_file_path}" \
-                > "${start_path}/infracost-base.yml"
+              # Multi-environment project: baseline dir has multiple tfvars files that
+              # infracost auto-detects as separate projects, causing false cost diffs.
+              # Skip baseline comparison; report absolute cost from the plan instead.
+              echo "Multi-environment project detected — reporting absolute cost from plan (no baseline diff)"
               infracost breakdown \
                 --log-level ${{ inputs.log_severity }} \
                 --no-color \
-                --config-file="${start_path}/infracost-base.yml" \
+                --path="$plan_path" \
                 --format=json \
-                --out-file="${start_path}/infracost-base.json" 2>&1 || {
-                echo "::warning::infracost baseline failed, skipping cost diff"
+                --out-file="${start_path}/infracost.json" 2>&1 || {
+                echo "::warning::infracost breakdown failed, skipping cost report"
                 exit 0
               }
             else
+              echo "Create infracost baseline using plan in base branch (main)"
               infracost breakdown \
                 --log-level ${{ inputs.log_severity }} \
                 --no-color \
@@ -1161,18 +1162,18 @@ jobs:
                 echo "::warning::infracost baseline failed, skipping cost diff"
                 exit 0
               }
+              echo "Compare current commit with baseline from plan in base branch (main)"
+              infracost diff \
+                --log-level ${{ inputs.log_severity }} \
+                --no-color \
+                --path="$plan_path" \
+                --format=json \
+                --compare-to="${start_path}/infracost-base.json" \
+                --out-file="${start_path}/infracost.json" 2>&1 || {
+                echo "::warning::infracost diff failed, skipping cost diff"
+                exit 0
+              }
             fi
-            echo "Compare current commit with baseline from plan in base branch (main)"
-            infracost diff \
-              --log-level ${{ inputs.log_severity }} \
-              --no-color \
-              --path="$plan_path" \
-              --format=json \
-              --compare-to="${start_path}/infracost-base.json" \
-              --out-file="${start_path}/infracost.json" 2>&1 || {
-              echo "::warning::infracost diff failed, skipping cost diff"
-              exit 0
-            }
           else
             echo "Create infracost breakdown using plan from current commit"
             infracost breakdown \

--- a/.github/workflows/terraform-job.yml
+++ b/.github/workflows/terraform-job.yml
@@ -1137,15 +1137,36 @@ jobs:
           fi
           if [[ -d "$main_path" ]] && [[ -n "$(find "$main_path" -maxdepth 1 -name "*.tf" -type f 2>/dev/null)" ]]; then
             echo "Create infracost baseline using plan in base branch (main)"
-            infracost breakdown \
-              --log-level ${{ inputs.log_severity }} \
-              --no-color \
-              --path="$main_path" \
-              --format=json \
-              --out-file="${start_path}/infracost-base.json" 2>&1 || {
-              echo "::warning::infracost baseline failed, skipping cost diff"
-              exit 0
-            }
+            var_file_path="${start_path}/main/${{ inputs.var_path }}/terraform.tfvars"
+            if [[ -f "$var_file_path" ]]; then
+              cat > "${start_path}/infracost-base.yml" << EOF
+version: 0.1
+projects:
+  - path: ${main_path}
+    name: ${{ github.repository }}
+    terraform_var_files:
+      - ${var_file_path}
+EOF
+              infracost breakdown \
+                --log-level ${{ inputs.log_severity }} \
+                --no-color \
+                --config-file="${start_path}/infracost-base.yml" \
+                --format=json \
+                --out-file="${start_path}/infracost-base.json" 2>&1 || {
+                echo "::warning::infracost baseline failed, skipping cost diff"
+                exit 0
+              }
+            else
+              infracost breakdown \
+                --log-level ${{ inputs.log_severity }} \
+                --no-color \
+                --path="$main_path" \
+                --format=json \
+                --out-file="${start_path}/infracost-base.json" 2>&1 || {
+                echo "::warning::infracost baseline failed, skipping cost diff"
+                exit 0
+              }
+            fi
             echo "Compare current commit with baseline from plan in base branch (main)"
             infracost diff \
               --log-level ${{ inputs.log_severity }} \

--- a/.github/workflows/terraform-job.yml
+++ b/.github/workflows/terraform-job.yml
@@ -1125,66 +1125,68 @@ jobs:
           set -Eeuo pipefail
           set -x
           start_path=$(readlink -f .)
-          main_path="${start_path}/main/${{ inputs.code_path }}"
-          mkdir -p ${start_path}/logs
+          state_storage_account_name='${{ inputs.state_storage_account_name }}'
+          mkdir -p "${start_path}/logs"
           touch "${start_path}/logs/steps.log"
-          if [ -f "${start_path}/plan.json" ] && [ -s "${start_path}/plan.json" ]; then
-            echo "Using pre-generated plan JSON for infracost ($(wc -c < ${start_path}/plan.json) bytes)"
-            plan_path="${start_path}/plan.json"
-          else
+          if [ ! -f "${start_path}/plan.json" ] || [ ! -s "${start_path}/plan.json" ]; then
             echo "::warning::plan.json not found — infracost skipped"
             exit 0
           fi
-          if [[ -d "$main_path" ]] && [[ -n "$(find "$main_path" -maxdepth 1 -name "*.tf" -type f 2>/dev/null)" ]]; then
-            var_file_path="${start_path}/main/${{ inputs.var_path }}/terraform.tfvars"
-            if [[ -f "$var_file_path" ]]; then
-              # Multi-environment project: baseline dir has multiple tfvars files that
-              # infracost auto-detects as separate projects, causing false cost diffs.
-              # Skip baseline comparison; report absolute cost from the plan instead.
-              echo "Multi-environment project detected — reporting absolute cost from plan (no baseline diff)"
-              infracost breakdown \
-                --log-level ${{ inputs.log_severity }} \
-                --no-color \
-                --path="$plan_path" \
-                --format=json \
-                --out-file="${start_path}/infracost.json" 2>&1 || {
-                echo "::warning::infracost breakdown failed, skipping cost report"
-                exit 0
-              }
-            else
-              echo "Create infracost baseline using plan in base branch (main)"
-              infracost breakdown \
-                --log-level ${{ inputs.log_severity }} \
-                --no-color \
-                --path="$main_path" \
-                --format=json \
-                --out-file="${start_path}/infracost-base.json" 2>&1 || {
-                echo "::warning::infracost baseline failed, skipping cost diff"
-                exit 0
-              }
-              echo "Compare current commit with baseline from plan in base branch (main)"
-              infracost diff \
-                --log-level ${{ inputs.log_severity }} \
-                --no-color \
-                --path="$plan_path" \
-                --format=json \
-                --compare-to="${start_path}/infracost-base.json" \
-                --out-file="${start_path}/infracost.json" 2>&1 || {
-                echo "::warning::infracost diff failed, skipping cost diff"
-                exit 0
-              }
-            fi
+          plan_path="${start_path}/plan.json"
+          echo "Using pre-generated plan JSON for infracost ($(wc -c < "${start_path}/plan.json") bytes)"
+          # Download previous infracost breakdown from blob storage (best-effort — no failure on miss)
+          infracost_prev=""
+          if [[ -n "$state_storage_account_name" ]] && az storage blob download \
+            --name "${PLAN_FOLDER}/infracost.json" \
+            --container-name "$PLAN_CONTAINER" \
+            --file "${start_path}/infracost-prev.json" \
+            --account-name "$state_storage_account_name" \
+            --auth-mode login \
+            --no-progress \
+            --only-show-errors \
+            -o none 2>/dev/null; then
+            echo "Downloaded previous infracost breakdown for baseline comparison"
+            infracost_prev="${start_path}/infracost-prev.json"
           else
-            echo "Create infracost breakdown using plan from current commit"
-            infracost breakdown \
+            echo "No previous infracost baseline found — reporting absolute cost"
+          fi
+          # Generate absolute cost breakdown from plan (for upload and as fallback)
+          infracost breakdown \
+            --log-level ${{ inputs.log_severity }} \
+            --no-color \
+            --path="$plan_path" \
+            --format=json \
+            --out-file="${start_path}/infracost-abs.json" 2>&1 || {
+            echo "::warning::infracost breakdown failed, skipping cost report"
+            exit 0
+          }
+          # Diff against previous baseline if available; otherwise use absolute
+          if [[ -n "$infracost_prev" ]]; then
+            infracost diff \
               --log-level ${{ inputs.log_severity }} \
               --no-color \
               --path="$plan_path" \
               --format=json \
+              --compare-to="$infracost_prev" \
               --out-file="${start_path}/infracost.json" 2>&1 || {
-              echo "::warning::infracost breakdown failed, skipping cost diff"
-              exit 0
+              echo "::warning::infracost diff failed, falling back to absolute cost"
+              cp "${start_path}/infracost-abs.json" "${start_path}/infracost.json"
             }
+          else
+            cp "${start_path}/infracost-abs.json" "${start_path}/infracost.json"
+          fi
+          # Upload current absolute breakdown so future runs can diff against it
+          if [[ -n "$state_storage_account_name" ]]; then
+            az storage blob upload \
+              --file "${start_path}/infracost-abs.json" \
+              --container-name "$PLAN_CONTAINER" \
+              --name "${PLAN_FOLDER}/infracost.json" \
+              --account-name "$state_storage_account_name" \
+              --auth-mode login \
+              --no-progress \
+              --overwrite \
+              --only-show-errors \
+              -o none 2>&1 || echo "::warning::infracost upload failed — future runs will not have baseline"
           fi
 
       - name: Add or update infrastructure cost comment


### PR DESCRIPTION
## Summary

- Replaces git-main baseline approach with blob-persisted baselines
- After each plan run, `infracost-abs.json` is uploaded to `${PLAN_FOLDER}/infracost.json` in the plan container
- Next run downloads it and uses it as the `--compare-to` target: true delta from last-known state, not a false diff caused by multi-env tfvars auto-detection
- First run (no prior upload) reports absolute cost; all subsequent runs show the real delta

## Why the previous approach failed

`infracost breakdown --path=<dir>` auto-detects each `.tfvars` file as a separate project (e.g. `environments/production/terraform.tfvars` → project "main-production"). This produced two rows with a net $0 "change" on every plan — a false delta. Using `--path=plan.json` instead anchors the project name to the repository, giving consistent matching across runs.

## Test

Verified end-to-end on `hoegh-autoliners/fr1nexus` PR #2 — infracost comment updated correctly, no false delta.