### PR TITLE
fix(infracost): environment-scoped baseline updated on apply, not per-PR plan

### DIFF
--- a/.github/workflows/terraform-job.yml
+++ b/.github/workflows/terraform-job.yml
@@ -1134,23 +1134,25 @@ jobs:
           fi
           plan_path="${start_path}/plan.json"
           echo "Using pre-generated plan JSON for infracost ($(wc -c < "${start_path}/plan.json") bytes)"
-          # Download previous infracost breakdown from blob storage (best-effort — no failure on miss)
+          # Download environment baseline from state container (keyed by state_name, best-effort)
+          # Baseline is only written after a successful apply, so it reflects what is deployed.
+          baseline_blob=$(echo '${{ inputs.state_name }}' | sed 's/\.tfstate$/-infracost.json/')
           infracost_prev=""
           if [[ -n "$state_storage_account_name" ]] && az storage blob download \
-            --name "${PLAN_FOLDER}/infracost.json" \
-            --container-name "$PLAN_CONTAINER" \
+            --name "$baseline_blob" \
+            --container-name '${{ inputs.state_container }}' \
             --file "${start_path}/infracost-prev.json" \
             --account-name "$state_storage_account_name" \
             --auth-mode login \
             --no-progress \
             --only-show-errors \
             -o none 2>/dev/null; then
-            echo "Downloaded previous infracost breakdown for baseline comparison"
+            echo "Downloaded environment infracost baseline for delta comparison"
             infracost_prev="${start_path}/infracost-prev.json"
           else
-            echo "No previous infracost baseline found — reporting absolute cost"
+            echo "No environment baseline found — reporting absolute cost"
           fi
-          # Generate absolute cost breakdown from plan (for upload and as fallback)
+          # Generate absolute cost breakdown from plan (used for diff and as fallback)
           infracost breakdown \
             --log-level ${{ inputs.log_severity }} \
             --no-color \
@@ -1160,7 +1162,7 @@ jobs:
             echo "::warning::infracost breakdown failed, skipping cost report"
             exit 0
           }
-          # Diff against previous baseline if available; otherwise use absolute
+          # Diff against environment baseline if available; otherwise report absolute cost
           if [[ -n "$infracost_prev" ]]; then
             infracost diff \
               --log-level ${{ inputs.log_severity }} \
@@ -1174,19 +1176,6 @@ jobs:
             }
           else
             cp "${start_path}/infracost-abs.json" "${start_path}/infracost.json"
-          fi
-          # Upload current absolute breakdown so future runs can diff against it
-          if [[ -n "$state_storage_account_name" ]]; then
-            az storage blob upload \
-              --file "${start_path}/infracost-abs.json" \
-              --container-name "$PLAN_CONTAINER" \
-              --name "${PLAN_FOLDER}/infracost.json" \
-              --account-name "$state_storage_account_name" \
-              --auth-mode login \
-              --no-progress \
-              --overwrite \
-              --only-show-errors \
-              -o none 2>&1 || echo "::warning::infracost upload failed — future runs will not have baseline"
           fi
 
       - name: Add or update infrastructure cost comment
@@ -1219,6 +1208,41 @@ jobs:
             --github-token='${{ secrets.GITHUB_TOKEN }}' \
             --pull-request=$PULL_REQUEST_NUMBER \
             --behavior=update
+
+      - name: Update infracost baseline
+        if: contains(inputs.terraform_command, 'apply')
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          set -x
+          start_path=$(readlink -f .)
+          state_storage_account_name='${{ inputs.state_storage_account_name }}'
+          if [ ! -f "${start_path}/plan.json" ] || [ ! -s "${start_path}/plan.json" ]; then
+            echo "::warning::plan.json not found — infracost baseline not updated"
+            exit 0
+          fi
+          baseline_blob=$(echo '${{ inputs.state_name }}' | sed 's/\.tfstate$/-infracost.json/')
+          infracost breakdown \
+            --log-level ${{ inputs.log_severity }} \
+            --no-color \
+            --path="${start_path}/plan.json" \
+            --format=json \
+            --out-file="${start_path}/infracost-baseline.json" 2>&1 || {
+            echo "::warning::infracost breakdown failed — baseline not updated"
+            exit 0
+          }
+          if [[ -n "$state_storage_account_name" ]]; then
+            az storage blob upload \
+              --file "${start_path}/infracost-baseline.json" \
+              --container-name '${{ inputs.state_container }}' \
+              --name "$baseline_blob" \
+              --account-name "$state_storage_account_name" \
+              --auth-mode login \
+              --no-progress \
+              --overwrite \
+              --only-show-errors \
+              -o none 2>&1 || echo "::warning::infracost baseline upload failed — future PRs will not have baseline"
+          fi
 
       - name: Auto merge when applied
         id: auto_merge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.0.10] - 2026-04-27
+
+### Fixed
+
+- **Infracost baseline scope** — the infracost baseline was previously keyed
+  per-PR (`definition-plan_{repo}_PR{number}`), meaning every new PR started
+  from zero and showed absolute cost rather than a cost delta. The baseline is
+  now keyed per-environment, derived from `state_name` (e.g.
+  `test/terraform.tfstate` → `test/terraform-infracost.json`) and stored in the
+  same state container. This gives a true cost delta for every PR: "what does
+  this change add or remove from what is currently deployed?"
+
+### Changed
+
+- **Infracost baseline updated on apply, not on plan** — a new "Update
+  infracost baseline" step runs after a successful `apply` and uploads the
+  post-apply breakdown as the environment baseline. Plan runs only read the
+  baseline; they no longer write it. This ensures the baseline always reflects
+  deployed infrastructure, not a speculative plan.
+
+---
+
 ## [v1.0.9] - 2026-04-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -455,16 +455,20 @@ jobs:
 ## Infracost cost reporting
 
 Each plan run generates an infrastructure cost report posted as a PR comment.
-The workflow stores the current run's cost breakdown in blob storage alongside
-the plan, and downloads the previous run's breakdown as a baseline on the next
-run. This means:
+The baseline is stored per-environment (keyed from `state_name`) in the same
+blob storage container as the Terraform state, and is updated only after a
+successful apply. This means:
 
-- **First plan on a new PR** — reports absolute monthly cost (no prior baseline).
-- **Subsequent plans on the same PR** — reports the delta from the last plan run,
-  giving an accurate view of cost impact even across multiple commits.
+- **First PR for an environment** — reports absolute monthly cost (no prior
+  baseline exists yet for that environment).
+- **All subsequent PRs** — reports the cost delta against what is currently
+  deployed in that environment, giving an accurate view of the cost impact of
+  the change regardless of how many PRs have been merged in between.
+- **After each successful `/apply`** — the environment baseline is updated to
+  reflect the newly deployed state, so the next PR diffs against it.
 
-The cost comment is updated in place on each plan run and remains on the PR after
-apply for audit purposes.
+The cost comment is updated in place on each plan run and remains on the PR
+after apply for audit purposes.
 
 ## Create GitHub App
 


### PR DESCRIPTION
## Problem

The previous implementation keyed the infracost baseline on the PR number (`definition-plan_{repo}_PR{number}`). This meant every new PR started from zero and showed absolute cost — the opposite of what's useful. A tag-only PR would show the full environment cost as if it were all new spend.

## Fix

**Baseline key:** derived from `state_name` (e.g. `test/terraform.tfstate` → `test/terraform-infracost.json`), stored in the state container alongside the Terraform state. Naturally environment-scoped.

**Baseline update trigger:** a new "Update infracost baseline" step runs only after a successful `apply`. Plan runs read the baseline but never write it, so the baseline always reflects what is actually deployed.

## Correct behaviour after this fix

| Scenario | Result |
|---|---|
| First PR for an environment | Absolute cost (no baseline yet) |
| Any subsequent PR | Delta from currently-deployed cost |
| Successful `/apply` | Baseline updated to new deployed state |
| Tag-only or no-cost PR | $0 delta |